### PR TITLE
Implement background DownloadManager service

### DIFF
--- a/Documentation/DownloadManagerGuide.md
+++ b/Documentation/DownloadManagerGuide.md
@@ -1,0 +1,122 @@
+# Download Manager Guide
+
+This document explains the background download service located under `Shared/Services/DownloadService`. It describes how it is structured, how to integrate it and how to use its API.
+
+## Overview
+
+The download service provides a lightweight API for downloading files in the background on iOS. It wraps a background `URLSession` and publishes progress and state updates through an async stream. Tasks are coordinated by an actor to limit concurrency and to handle pause/resume operations. Files are stored under the app's `Downloads` directory with basic disk quota checks.
+
+## Setup
+
+1. Ensure the `Shared/Services/DownloadService` folder is included in your target.
+2. In your `UIApplicationDelegate` implement `application(_:handleEventsForBackgroundURLSession:completionHandler:)` and forward the completion handler to `NetworkLayer.shared`:
+   ```swift
+   func application(_ application: UIApplication,
+                    handleEventsForBackgroundURLSession identifier: String,
+                    completionHandler: @escaping () -> Void) {
+       NetworkLayer.shared.backgroundCompletionHandler = completionHandler
+   }
+   ```
+3. Obtain the manager via the dependency container or instantiate it directly:
+   ```swift
+   let downloadManager = Container.shared.backgroundDownloadManager()
+   ```
+   or
+   ```swift
+   let downloadManager = DownloadManager()
+   ```
+
+## Components
+
+### `DownloadManager`
+Facade conforming to `DownloadManagerProtocol`. Creates a `TaskCoordinator` and exposes an async stream of `DownloadEvent` values.
+
+### `TaskCoordinator`
+An `actor` maintaining an active set of downloads and a queue. It limits the number of concurrent tasks, forwards progress, and moves completed files via `StorageManager`.
+
+### `NetworkLayer`
+Owns the background `URLSession`. Delegate callbacks notify the `TaskCoordinator` about progress or completion.
+
+### `StorageManager`
+Handles the local filesystem: determines destination paths, checks available space and moves files while excluding them from iCloud backups.
+
+## API
+
+### `DownloadManagerProtocol`
+```swift
+public protocol DownloadManagerProtocol {
+    @discardableResult
+    func enqueue(_ item: URL, priority: TaskPriority) async -> DownloadID
+    func pause(_ id: DownloadID) async
+    func resume(_ id: DownloadID) async
+    func cancel(_ id: DownloadID) async
+    var events: AsyncStream<DownloadEvent> { get }
+}
+```
+
+#### Methods
+* `enqueue(_ item: URL, priority: TaskPriority)` – starts downloading `item` with the given priority and returns a `DownloadID` used to control the task.
+* `pause(_ id: DownloadID)` – pauses an active download if possible. Resume data is preserved to allow resuming later.
+* `resume(_ id: DownloadID)` – resumes a paused or queued download.
+* `cancel(_ id: DownloadID)` – cancels the download and emits a `.failed` event with the `.cancelled` error.
+* `events` – asynchronous sequence of `DownloadEvent` values to observe task status.
+
+### `DownloadEvent`
+```swift
+public enum DownloadEvent {
+    case started(DownloadID)
+    case progress(DownloadID, Double)   // progress in the range 0–1
+    case completed(DownloadID, URL)     // file moved to final location
+    case failed(DownloadID, DownloadError)
+}
+```
+
+### `DownloadError`
+```swift
+public enum DownloadError: Error {
+    case network
+    case server
+    case diskFull
+    case cancelled
+    case unknown
+}
+```
+
+### `DownloadManager` Initializer
+```swift
+init(maxConcurrent: Int = 3, storage: StorageManager = StorageManager())
+```
+* `maxConcurrent` – Maximum number of simultaneous downloads.
+* `storage` – Instance handling file storage. Defaults to a manager rooted in `URL.downloads`.
+
+## Usage Example
+
+```swift
+let manager = DownloadManager()  // or via Container.shared
+let taskID = await manager.enqueue(mediaURL, priority: .utility)
+
+Task.detached {
+    for await event in manager.events {
+        switch event {
+        case .progress(let id, let value) where id == taskID:
+            print("progress", value)
+        case .completed(let id, let url) where id == taskID:
+            print("saved to", url)
+        case .failed(let id, let error) where id == taskID:
+            print("failed", error)
+        default:
+            break
+        }
+    }
+}
+```
+
+You may call `pause(_:)`, `resume(_:)` or `cancel(_:)` with the `DownloadID` to control the task.
+
+## Limitations
+
+* Tasks are not persisted across app launches.
+* No retry mechanism is implemented beyond the resume data when pausing.
+* Disk quota checks are minimal; adjust `StorageManager` as needed.
+
+This service can serve as a starting point for integrating background downloads in your app. Extend the `TaskCoordinator` or `StorageManager` to support additional features such as retry policies, persistence or background task scheduling.

--- a/Shared/Services/DownloadService/DownloadManager.swift
+++ b/Shared/Services/DownloadService/DownloadManager.swift
@@ -1,0 +1,49 @@
+import Foundation
+import os.log
+
+/// Concrete implementation of `DownloadManagerProtocol` used across the app.
+final class DownloadManager: DownloadManagerProtocol {
+    static let shared = DownloadManager()
+
+    private let eventsStream: AsyncStream<DownloadEvent>
+    private let continuation: AsyncStream<DownloadEvent>.Continuation
+    private let coordinator: TaskCoordinator
+
+    init(maxConcurrent: Int = 3, storage: StorageManager = StorageManager()) {
+        var cont: AsyncStream<DownloadEvent>.Continuation!
+        self.eventsStream = AsyncStream { continuation in
+            cont = continuation
+        }
+        self.continuation = cont
+        self.coordinator = TaskCoordinator(maxConcurrent: maxConcurrent, storage: storage, continuation: cont)
+    }
+
+    var events: AsyncStream<DownloadEvent> { eventsStream }
+
+    func enqueue(_ item: URL, priority: TaskPriority) async -> DownloadID {
+        let id = DownloadID()
+        let record = DownloadRecord(id: id, url: item, priority: priority)
+        await coordinator.enqueue(record)
+        return id
+    }
+
+    func pause(_ id: DownloadID) async {
+        await coordinator.pause(id: id)
+    }
+
+    func resume(_ id: DownloadID) async {
+        await coordinator.resume(id: id)
+    }
+
+    func cancel(_ id: DownloadID) async {
+        await coordinator.cancel(id: id)
+    }
+}
+
+import Factory
+
+extension Container {
+    var backgroundDownloadManager: Factory<DownloadManager> {
+        self { DownloadManager() }.shared
+    }
+}

--- a/Shared/Services/DownloadService/DownloadManagerProtocol.swift
+++ b/Shared/Services/DownloadService/DownloadManagerProtocol.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// High level interface for the download manager.
+public protocol DownloadManagerProtocol {
+    @discardableResult
+    func enqueue(_ item: URL, priority: TaskPriority) async -> DownloadID
+    func pause(_ id: DownloadID) async
+    func resume(_ id: DownloadID) async
+    func cancel(_ id: DownloadID) async
+    var events: AsyncStream<DownloadEvent> { get }
+}

--- a/Shared/Services/DownloadService/DownloadTypes.swift
+++ b/Shared/Services/DownloadService/DownloadTypes.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Unique identifier for download tasks.
+public typealias DownloadID = UUID
+
+/// Possible events emitted by `DownloadManager`.
+public enum DownloadEvent {
+    case started(DownloadID)
+    case progress(DownloadID, Double)
+    case completed(DownloadID, URL)
+    case failed(DownloadID, DownloadError)
+}
+
+/// Errors that may occur during downloads.
+public enum DownloadError: Error {
+    case network
+    case server
+    case diskFull
+    case cancelled
+    case unknown
+}

--- a/Shared/Services/DownloadService/NetworkLayer.swift
+++ b/Shared/Services/DownloadService/NetworkLayer.swift
@@ -1,0 +1,49 @@
+import Foundation
+import os.log
+
+/// Network layer that manages the background URLSession.
+final class NetworkLayer: NSObject {
+    static let shared = NetworkLayer()
+
+    /// Completion handler provided by the app delegate when the background session finishes.
+    var backgroundCompletionHandler: (() -> Void)?
+
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: "org.jellyfin.swiftfin.download")
+        configuration.sessionSendsLaunchEvents = true
+        configuration.waitsForConnectivity = true
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    func createTask(for url: URL, identifier: DownloadID) -> URLSessionDownloadTask {
+        let task = session.downloadTask(with: url)
+        task.taskDescription = identifier.uuidString
+        return task
+    }
+}
+
+extension NetworkLayer: URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard let idString = downloadTask.taskDescription, let id = UUID(uuidString: idString) else { return }
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        Task { await TaskCoordinator.shared?.updateProgress(for: id, progress: progress) }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        guard let idString = downloadTask.taskDescription, let id = UUID(uuidString: idString) else { return }
+        Task { await TaskCoordinator.shared?.completed(id: id, location: location) }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error, let idString = task.taskDescription, let id = UUID(uuidString: idString) else { return }
+        Task { await TaskCoordinator.shared?.failed(id: id, error: error) }
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        backgroundCompletionHandler?()
+        backgroundCompletionHandler = nil
+    }
+}

--- a/Shared/Services/DownloadService/StorageManager.swift
+++ b/Shared/Services/DownloadService/StorageManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Manages storage locations and disk quota.
+final class StorageManager {
+    private let root: URL
+    private let quotaBytes: Int64
+
+    init(root: URL = .downloads, quotaBytes: Int64 = Int64(1_000_000_000)) {
+        self.root = root
+        self.quotaBytes = quotaBytes
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    func destination(for url: URL) -> URL {
+        root.appendingPathComponent(url.lastPathComponent)
+    }
+
+    func hasSpace(for bytes: Int64) -> Bool {
+        let free = FileManager.default.availableStorage
+        return free > bytes && free > 5_000_000 && usedSpace() + bytes < quotaBytes
+    }
+
+    func move(temp: URL, to destination: URL) throws {
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: temp, to: destination)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try destination.setResourceValues(values)
+    }
+
+    func usedSpace() -> Int64 {
+        return Int64((try? root.directoryTotalAllocatedSize(includingSubfolders: true)) ?? 0)
+    }
+}

--- a/Shared/Services/DownloadService/TaskCoordinator.swift
+++ b/Shared/Services/DownloadService/TaskCoordinator.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Actor responsible for coordinating download tasks and applying policies.
+actor TaskCoordinator {
+    static var shared: TaskCoordinator?
+
+    private var active: [DownloadID: DownloadRecord] = [:]
+    private var queue: [DownloadRecord] = []
+    private let maxConcurrent: Int
+    private let storage: StorageManager
+    private let eventContinuation: AsyncStream<DownloadEvent>.Continuation
+
+    init(maxConcurrent: Int, storage: StorageManager, continuation: AsyncStream<DownloadEvent>.Continuation) {
+        self.maxConcurrent = maxConcurrent
+        self.storage = storage
+        self.eventContinuation = continuation
+        TaskCoordinator.shared = self
+    }
+
+    func enqueue(_ record: DownloadRecord) {
+        queue.append(record)
+        queue.sort { $0.priority.rawValue > $1.priority.rawValue }
+        tick()
+    }
+
+    func pause(id: DownloadID) {
+        guard let record = active[id] else { return }
+        record.task?.cancel(byProducingResumeData: { data in
+            record.resumeData = data
+            record.state = .paused
+            self.active.removeValue(forKey: id)
+            self.queue.insert(record, at: 0)
+        })
+    }
+
+    func resume(id: DownloadID) {
+        if let index = queue.firstIndex(where: { $0.id == id }) {
+            queue[index].state = .queued
+        }
+        tick()
+    }
+
+    func cancel(id: DownloadID) {
+        if let record = active[id] {
+            record.task?.cancel()
+            active.removeValue(forKey: id)
+        } else if let index = queue.firstIndex(where: { $0.id == id }) {
+            queue.remove(at: index)
+        }
+        eventContinuation.yield(.failed(id, .cancelled))
+        tick()
+    }
+
+    func updateProgress(for id: DownloadID, progress: Double) {
+        eventContinuation.yield(.progress(id, progress))
+    }
+
+    func completed(id: DownloadID, location: URL) async {
+        guard let record = active[id] else { return }
+        do {
+            let dest = storage.destination(for: record.url)
+            try storage.move(temp: location, to: dest)
+            eventContinuation.yield(.completed(id, dest))
+            active.removeValue(forKey: id)
+            tick()
+        } catch {
+            eventContinuation.yield(.failed(id, .diskFull))
+        }
+    }
+
+    func failed(id: DownloadID, error: Error) {
+        active.removeValue(forKey: id)
+        eventContinuation.yield(.failed(id, .network))
+        tick()
+    }
+
+    private func tick() {
+        guard active.count < maxConcurrent else { return }
+        guard !queue.isEmpty else { return }
+        let record = queue.removeFirst()
+        start(record)
+    }
+
+    private func start(_ record: DownloadRecord) {
+        guard storage.hasSpace(for: record.expectedBytes) else {
+            eventContinuation.yield(.failed(record.id, .diskFull))
+            return
+        }
+        let task: URLSessionDownloadTask
+        if let resume = record.resumeData {
+            task = NetworkLayer.shared.session.downloadTask(withResumeData: resume)
+        } else {
+            task = NetworkLayer.shared.createTask(for: record.url, identifier: record.id)
+        }
+        record.task = task
+        record.state = .downloading
+        active[record.id] = record
+        task.resume()
+        eventContinuation.yield(.started(record.id))
+    }
+}
+
+/// Simple record describing a task managed by the coordinator.
+final class DownloadRecord {
+    let id: DownloadID
+    let url: URL
+    var state: State = .queued
+    var resumeData: Data?
+    weak var task: URLSessionDownloadTask?
+    let expectedBytes: Int64
+    let priority: TaskPriority
+
+    enum State { case queued, downloading, paused }
+
+    init(id: DownloadID = .init(), url: URL, expectedBytes: Int64 = 0, priority: TaskPriority) {
+        self.id = id
+        self.url = url
+        self.expectedBytes = expectedBytes
+        self.priority = priority
+    }
+}

--- a/Swiftfin/App/AppDelegate.swift
+++ b/Swiftfin/App/AppDelegate.swift
@@ -31,4 +31,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         return true
     }
+
+    func application(_ application: UIApplication,
+                     handleEventsForBackgroundURLSession identifier: String,
+                     completionHandler: @escaping () -> Void) {
+        NetworkLayer.shared.backgroundCompletionHandler = completionHandler
+    }
 }


### PR DESCRIPTION
## Summary
- add a new modular DownloadService with NetworkLayer, TaskCoordinator and StorageManager
- expose a `DownloadManager` API conforming to `DownloadManagerProtocol`
- hook background URLSession handling in `AppDelegate`
- document how to use the new service

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d84a4e48c83289b4dd4a2e4a7941d